### PR TITLE
Use package caching correctly

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,8 +33,8 @@ jobs:
           packages: |
             any::rmarkdown
             any::dplyr
-            any::ggplot2
-            any::plotly
+            ggplot2@v3.5.1
+            plotly@v4.10.4
             any::sessioninfo
 
       - name: Render and Publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
           cache-version: 1
-          extra-packages: |
+          packages: |
             any::rmarkdown
             any::dplyr
             any::ggplot2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           cache-version: 1
           packages: |
+            deps::.
             any::rmarkdown
             any::dplyr
             any::ggplot2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/cache@v3
         id: cache
         with:
-          path: ${{ github.workspace }}
+          path: ${{ env.R_LIBS_USER }}
           key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
           restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,14 +14,6 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Cache R packages
-        uses: actions/cache@v3
-        id: cache
-        with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
-
       - name: Install libcurl
         run: |
           sudo apt-get install libcurl4-openssl-dev
@@ -35,14 +27,15 @@ jobs:
           r-version: '4.4.0'
 
       - name: Install R Packages
-        # if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          installed.packages()
-          dependencies <- c("rmarkdown", "dplyr", "ggplot2", "plotly", "sessioninfo")
-          needs_installation <- dependencies[!dependencies %in% installed.packages()]
-          install.packages(needs_installation)
-          library("rmarkdown")
-        shell: Rscript {0}
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          cache-version: 1
+          extra-packages: |
+            any::rmarkdown
+            any::dplyr
+            any::ggplot2
+            any::plotly
+            any::sessioninfo
 
       - name: Render and Publish
         uses: quarto-dev/quarto-actions/publish@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,8 +33,8 @@ jobs:
           packages: |
             any::rmarkdown
             any::dplyr
-            ggplot2@v3.5.1
-            plotly@v4.10.4
+            ggplot2@3.5.1
+            plotly@4.10.4
             any::sessioninfo
 
       - name: Render and Publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,6 @@ jobs:
         with:
           cache-version: 1
           packages: |
-            deps::.
             any::rmarkdown
             any::dplyr
             any::ggplot2


### PR DESCRIPTION
Currently, a cache is being created when the publish action runs, but the R package installation step is not accessing the R packages from that cache. This should cut the deployment time by 5-6 minutes